### PR TITLE
Support "atom:published" element

### DIFF
--- a/src/main/java/fr/vidal/oss/jaxb/atom/core/Entry.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/core/Entry.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import static java.util.Collections.unmodifiableCollection;
 
 @XmlType(propOrder = {
-    "title", "links", "category", "author", "id", "updateDate", "summary", "contents", "additionalElements"
+    "title", "links", "category", "author", "id", "publishedDate", "updateDate", "summary", "contents", "additionalElements"
 })
 public class Entry {
 
@@ -24,6 +24,8 @@ public class Entry {
     private final Category category;
     @XmlElement(name = "id", required = true)
     private final String id;
+    @XmlElement(name = "published")
+    private final Date publishedDate;
     @XmlElement(name = "updated", required = true)
     private final Date updateDate;
     @XmlElement(name = "author")
@@ -49,8 +51,8 @@ public class Entry {
         links = builder.links;
         summary = builder.summary;
         title = builder.title;
+        publishedDate = builder.publishedDate;
         updateDate = builder.updateDate;
-
     }
 
     public String getTitle() {
@@ -69,6 +71,10 @@ public class Entry {
         return id;
     }
 
+    public Date getPublishedDate() {
+        return publishedDate;
+    }
+    
     public Date getUpdateDate() {
         return updateDate;
     }
@@ -113,6 +119,7 @@ public class Entry {
             ", summary=" + summary +
             ", category=" + category +
             ", id='" + id + '\'' +
+            ", publishedDate=" + publishedDate +
             ", updateDate=" + updateDate +
             ", author=" + author +
             ", contents=" + contents +
@@ -127,6 +134,7 @@ public class Entry {
         private Summary summary;
         private Category category;
         private String id;
+        private Date publishedDate;
         private Date updateDate;
         private Author author;
         private Contents contents = Contents.EMPTY;
@@ -150,6 +158,11 @@ public class Entry {
 
         public Builder withId(String id){
             this.id = id;
+            return this;
+        }
+
+        public Builder withPublishedDate(final Date publishedDate){
+            this.publishedDate = publishedDate;
             return this;
         }
 

--- a/src/main/java/fr/vidal/oss/jaxb/atom/core/Feed.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/core/Feed.java
@@ -1,15 +1,15 @@
 package fr.vidal.oss.jaxb.atom.core;
 
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import static java.util.Collections.unmodifiableCollection;
+
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Objects;
-
-import static java.util.Collections.unmodifiableCollection;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name = "feed")
 @XmlType(propOrder = {"title", "subtitle", "links", "id", "author", "updateDate", "additionalElements", "entries"})

--- a/src/test/java/fr/vidal/oss/jaxb/atom/DateBuilder.java
+++ b/src/test/java/fr/vidal/oss/jaxb/atom/DateBuilder.java
@@ -1,0 +1,13 @@
+package fr.vidal.oss.jaxb.atom;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public final class DateBuilder {
+    private DateBuilder() {}
+
+    static Date isoDate(final String date) throws ParseException {
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(date);
+    }
+}

--- a/src/test/java/fr/vidal/oss/jaxb/atom/MarshallingTest.java
+++ b/src/test/java/fr/vidal/oss/jaxb/atom/MarshallingTest.java
@@ -1,25 +1,32 @@
 package fr.vidal.oss.jaxb.atom;
 
-import fr.vidal.oss.jaxb.atom.core.*;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Date;
-import java.util.TimeZone;
+import fr.vidal.oss.jaxb.atom.core.Category;
+import fr.vidal.oss.jaxb.atom.core.Entry;
+import fr.vidal.oss.jaxb.atom.core.Feed;
+import fr.vidal.oss.jaxb.atom.core.Link;
+import fr.vidal.oss.jaxb.atom.core.SimpleElement;
+import fr.vidal.oss.jaxb.atom.core.Summary;
 
 import static fr.vidal.oss.jaxb.atom.core.Attribute.attribute;
 import static fr.vidal.oss.jaxb.atom.core.Author.author;
 import static fr.vidal.oss.jaxb.atom.core.DateAdapter.DATE_FORMAT;
 import static fr.vidal.oss.jaxb.atom.core.Feed.Builder;
-import static fr.vidal.oss.jaxb.atom.core.LinkRel.*;
+import static fr.vidal.oss.jaxb.atom.core.LinkRel.alternate;
+import static fr.vidal.oss.jaxb.atom.core.LinkRel.related;
+import static fr.vidal.oss.jaxb.atom.core.LinkRel.self;
 import static fr.vidal.oss.jaxb.atom.core.Namespace.namespace;
 import static java.util.TimeZone.getTimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.TimeZone;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MarshallingTest {
 
@@ -34,7 +41,7 @@ public class MarshallingTest {
     }
 
     @Test
-    public void marshalls_standard_atom_feed() throws JAXBException, IOException {
+    public void marshalls_standard_atom_feed() throws Exception {
         Builder feedBuilder = new Builder();
         feedBuilder.withId("urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6");
         feedBuilder.withTitle("My standard Atom 1.0 feed");
@@ -47,6 +54,7 @@ public class MarshallingTest {
         builder.addLink(new Link.Builder().withHref("http://example.org/2003/12/13/atom03").build());
         builder.withTitle("Atom is not what you think");
         builder.withId("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a");
+        builder.withPublishedDate(DateBuilder.isoDate("1977-02-05T01:00:00"));
         builder.withUpdateDate(new Date(512697600000L));
         builder.withSummary(new Summary("April's fool!", null));
 
@@ -70,6 +78,7 @@ public class MarshallingTest {
                         "        <title>Atom is not what you think</title>\n" +
                         "        <link href=\"http://example.org/2003/12/13/atom03\"/>\n" +
                         "        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>\n" +
+                        "        <published>1977-02-05T01:00:00Z</published>\n" +
                         "        <updated>1986-04-01T02:00:00Z</updated>\n" +
                         "        <summary>April's fool!</summary>\n" +
                         "        <content/>\n" +
@@ -131,23 +140,23 @@ public class MarshallingTest {
                     )
                     .build()
             ).addEntry(
-                new Entry.Builder()
-                    .withTitle("SNAKE OIL 1 mg")
-                    .addLink(new Link.Builder().withRel(alternate).withType("application/atom+xml").withHref("/rest/api/product/42").build())
-                    .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/packages").withTitle("PACKAGES").build())
-                    .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/documents").withTitle("DOCUMENTS").build())
-                    .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/documents/opt").withTitle("OPT_DOCUMENT").build())
-                    .withCategory(new Category("PRODUCT"))
-                    .withAuthor(author("VIDAL"))
-                    .withId("vidal://product/42")
-                    .withUpdateDate(new Date(1329350400000L))
-                    .withSummary(new Summary("SNAKE OIL 1 mg", "text"))
-                    .addSimpleElement(new SimpleElement.Builder()
-                            .withNamespace(namespace("http://api.vidal.net/-/spec/vidal-api/1.0/", "vidal"))
-                            .withTagName("id")
-                            .withValue(String.valueOf(42))
-                            .build()
-                    ).build()
+            new Entry.Builder()
+                .withTitle("SNAKE OIL 1 mg")
+                .addLink(new Link.Builder().withRel(alternate).withType("application/atom+xml").withHref("/rest/api/product/42").build())
+                .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/packages").withTitle("PACKAGES").build())
+                .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/documents").withTitle("DOCUMENTS").build())
+                .addLink(new Link.Builder().withRel(related).withType("application/atom+xml").withHref("/rest/api/product/42/documents/opt").withTitle("OPT_DOCUMENT").build())
+                .withCategory(new Category("PRODUCT"))
+                .withAuthor(author("VIDAL"))
+                .withId("vidal://product/42")
+                .withUpdateDate(new Date(1329350400000L))
+                .withSummary(new Summary("SNAKE OIL 1 mg", "text"))
+                .addSimpleElement(new SimpleElement.Builder()
+                        .withNamespace(namespace("http://api.vidal.net/-/spec/vidal-api/1.0/", "vidal"))
+                        .withTagName("id")
+                        .withValue(String.valueOf(42))
+                        .build()
+                ).build()
         );
 
         try (StringWriter writer = new StringWriter()) {
@@ -206,4 +215,6 @@ public class MarshallingTest {
                     "</feed>");
         }
     }
+
+
 }

--- a/src/test/java/fr/vidal/oss/jaxb/atom/UnmarshallingTest.java
+++ b/src/test/java/fr/vidal/oss/jaxb/atom/UnmarshallingTest.java
@@ -7,17 +7,6 @@ import fr.vidal.oss.jaxb.atom.core.Link;
 import fr.vidal.oss.jaxb.atom.core.LinkRel;
 import fr.vidal.oss.jaxb.atom.core.SimpleElement;
 import fr.vidal.oss.jaxb.atom.core.Summary;
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.InputSource;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import java.io.StringReader;
-import java.util.Collection;
-import java.util.Date;
-import java.util.TimeZone;
 
 import static fr.vidal.oss.jaxb.atom.Assertions.assertThat;
 import static fr.vidal.oss.jaxb.atom.core.Attribute.attribute;
@@ -26,6 +15,17 @@ import static fr.vidal.oss.jaxb.atom.core.Contents.contents;
 import static fr.vidal.oss.jaxb.atom.core.DateAdapter.DATE_FORMAT;
 import static fr.vidal.oss.jaxb.atom.core.Namespace.namespace;
 import static java.util.TimeZone.getTimeZone;
+
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.Date;
+import java.util.TimeZone;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.InputSource;
 
 public class UnmarshallingTest {
 
@@ -54,6 +54,7 @@ public class UnmarshallingTest {
             "        <title>Atom is not what you think</title>\n" +
             "        <link href=\"http://example.org/2003/12/13/atom03\"/>\n" +
             "        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>\n" +
+            "        <published>1977-02-05T01:00:00Z</published>\n" +
             "        <updated>1986-04-01T02:00:00Z</updated>\n" +
             "        <summary>April's fool!</summary>\n" +
             "        <content>Entry content</content>\n" +
@@ -81,6 +82,7 @@ public class UnmarshallingTest {
                 new Link.Builder()
                     .withHref("http://example.org/2003/12/13/atom03")
                     .build())
+            .hasPublishedDate(DateBuilder.isoDate("1977-02-05T01:00:00"))
             .hasUpdateDate(new Date(512697600000L))
             .hasSummary(new Summary("April's fool!", null))
             .hasContents(contents("Entry content"));
@@ -197,4 +199,5 @@ public class UnmarshallingTest {
     private static Entry entry(String id) {
         return new Entry.Builder().withId(id).build();
     }
+
 }


### PR DESCRIPTION
Quote from RFC 4287:
 The "atom:published" element is a Date construct indicating an
 instant in time associated with an event early in the life cycle of
 the entry.